### PR TITLE
add headers to messages, add header handlers for publisher and subscriber

### DIFF
--- a/MyJetWallet.Sdk.ServiceBus.sln
+++ b/MyJetWallet.Sdk.ServiceBus.sln
@@ -1,19 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30804.86
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A9BF0F63-0AC7-40BB-AC7B-14179C3295DD}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\ci-test.yml = .github\workflows\ci-test.yml
 		README.md = README.md
 		.github\workflows\release-api-client.yml = .github\workflows\release-api-client.yml
-		.github\workflows\ci-test.yml = .github\workflows\ci-test.yml
 		.github\workflows\update_nuget.yaml = .github\workflows\update_nuget.yaml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyJetWallet.Sdk.ServiceBus", "src\MyJetWallet.Sdk.ServiceBus\MyJetWallet.Sdk.ServiceBus.csproj", "{B9356BD3-D898-43F4-AA60-83CB0E85C71E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyJetWallet.Sdk.ServiceBus", "src\MyJetWallet.Sdk.ServiceBus\MyJetWallet.Sdk.ServiceBus.csproj", "{B9356BD3-D898-43F4-AA60-83CB0E85C71E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp", "src\TestApp\TestApp.csproj", "{2D6E76ED-C41F-4162-AB0F-43DF32B4DF3B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp", "src\TestApp\TestApp.csproj", "{2D6E76ED-C41F-4162-AB0F-43DF32B4DF3B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyJetWallet.Sdk.ServiceBus.Tests", "test\MyJetWallet.Sdk.ServiceBus.Tests\MyJetWallet.Sdk.ServiceBus.Tests.csproj", "{2400ECCC-86E6-4DC5-8F9C-13096706CE21}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,6 +31,10 @@ Global
 		{2D6E76ED-C41F-4162-AB0F-43DF32B4DF3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D6E76ED-C41F-4162-AB0F-43DF32B4DF3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D6E76ED-C41F-4162-AB0F-43DF32B4DF3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2400ECCC-86E6-4DC5-8F9C-13096706CE21}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2400ECCC-86E6-4DC5-8F9C-13096706CE21}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2400ECCC-86E6-4DC5-8F9C-13096706CE21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2400ECCC-86E6-4DC5-8F9C-13096706CE21}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MyJetWallet.Sdk.ServiceBus/IServiceBusPublisher.cs
+++ b/src/MyJetWallet.Sdk.ServiceBus/IServiceBusPublisher.cs
@@ -1,12 +1,11 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace MyJetWallet.Sdk.ServiceBus
+namespace MyJetWallet.Sdk.ServiceBus;
+
+public interface IServiceBusPublisher<in T>
 {
-    public interface IServiceBusPublisher<in T>
-    {
-        Task PublishAsync(T message);
-        
-        Task PublishAsync(IEnumerable<T> messageList);
-    }
+    Task PublishAsync(T message, Dictionary<string, string> headers = null);
+    
+    Task PublishAsync(IEnumerable<T> messageList, Dictionary<string, string> headers = null);
 }

--- a/src/MyJetWallet.Sdk.ServiceBus/Mappers/ContractToDomainMapper.cs
+++ b/src/MyJetWallet.Sdk.ServiceBus/Mappers/ContractToDomainMapper.cs
@@ -1,38 +1,59 @@
-using System;
-using System.IO;
+using MyJetWallet.Sdk.ServiceBus.Models;
 using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace MyJetWallet.Sdk.ServiceBus
 {
     public static class ContractToDomainMapper
     {
-        public static T ByteArrayToServiceBusContract<T>(this ReadOnlyMemory<byte> data)
+        public static MessageWithHeaders<T> ByteArrayToServiceBusContract<T>(this ReadOnlyMemory<byte> data)
         {
+            var result = new MessageWithHeaders<T>();
             if (ServiceBusContracts.IsDebug)
                 Console.WriteLine($"GOT {typeof(T)} MESSAGE LEN:" + data.Length);
 
             var span = data.Span;
-
-            if (span[0] == 0)
+            try
             {
-                try
+                switch(span[0])
                 {
-                    span = data.Slice(1, data.Length - 1).Span;
-                    var mem = new MemoryStream(data.Length);
-                    mem.Write(span);
-                    mem.Position = 0;
-                    return ProtoBuf.Serializer.Deserialize<T>(mem);
+                    case 0:
+                        span = data[1..].Span;
+                        break;
+                    case 1:
+                        var headerLength = BitConverter.ToInt16(span.Slice(1, 2));
+                        result.Headers = DeserializeHeaders(data, headerLength);
+                        var startMessage = 3 + headerLength; // 1 byte for version, 2 bytes for header length
+                        span = data[startMessage..].Span;
+                        break;
+                    default:
+                        throw new Exception("Not supported version of Contract");
                 }
-                catch (Exception ex)
-                {
-                    var dataBase64 = Convert.ToBase64String(data.ToArray());
-                    Console.WriteLine($"Cannot deserialize message {typeof(T).Name}. Data: '{dataBase64}'");
+                using var mem = new MemoryStream(span.Length);
+                mem.Write(span);
+                mem.Position = 0;
+                result.Data = Serializer.Deserialize<T>(mem);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                var dataBase64 = Convert.ToBase64String(data.ToArray());
+                Console.WriteLine($"Cannot deserialize message {typeof(T).Name}. Data: '{dataBase64}'");
 
-                    throw new Exception($"Cannot deserialize message {typeof(T).Name}: {ex.Message}", ex);
-                }
+                throw new Exception($"Cannot deserialize message {typeof(T).Name}: {ex.Message}", ex);
             }
 
             throw new Exception("Not supported version of Contract");
+        }
+
+        private static Dictionary<string,string> DeserializeHeaders(ReadOnlyMemory<byte> data, short headerLength)
+        {
+            using var mem = new MemoryStream(headerLength);
+            mem.Write(data.Slice(3, headerLength).Span);
+            mem.Position = 0;
+            return Serializer.Deserialize<Dictionary<string, string>>(mem);
         }
     }
 }

--- a/src/MyJetWallet.Sdk.ServiceBus/Models/MessageWithHeaders.cs
+++ b/src/MyJetWallet.Sdk.ServiceBus/Models/MessageWithHeaders.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace MyJetWallet.Sdk.ServiceBus.Models;
+
+public class MessageWithHeaders<T>
+{
+    public T Data { get; set; }
+    public Dictionary<string, string> Headers { get; set; } = [];
+}

--- a/src/MyJetWallet.Sdk.ServiceBus/MyServiceBusSubscriber.cs
+++ b/src/MyJetWallet.Sdk.ServiceBus/MyServiceBusSubscriber.cs
@@ -6,200 +6,204 @@ using DotNetCoreDecorators;
 using MyServiceBus.Abstractions;
 using MyServiceBus.TcpClient;
 
-namespace MyJetWallet.Sdk.ServiceBus
+namespace MyJetWallet.Sdk.ServiceBus;
+
+public class MyServiceBusSubscriber<T> : ISubscriber<T>, ISubscriber<IReadOnlyList<T>>
 {
-    public class MyServiceBusSubscriber<T> : ISubscriber<T>, ISubscriber<IReadOnlyList<T>>
+    private readonly int _chunkSize;
+    private readonly bool _batchSubscribe;
+    private Action<Exception> _deserializeExceptionHandler;
+    private Action<Dictionary<string, string>> _headersHandler;
+    private readonly bool _withDeduplication = false;
+    private readonly List<Func<T, ValueTask>> _list = new();
+    private readonly List<Func<IReadOnlyList<T>, ValueTask>> _listBatch = new();
+    private readonly IDeduplicator<T> _deduplicator;
+
+    public MyServiceBusSubscriber(
+        MyServiceBusTcpClient client,
+        string topicName, string queueName, TopicQueueType queryType, bool batchSubscribe,
+        bool withDeduplication)
     {
-        private readonly int _chunkSize;
-        private readonly bool _batchSubscribe;
-        private Action<Exception> _deserializeExceptionHandler;
-        private readonly bool _withDeduplication = false;
-        private readonly List<Func<T, ValueTask>> _list = new();
-        private readonly List<Func<IReadOnlyList<T>, ValueTask>> _listBatch = new();
-        private readonly IDeduplicator<T> _deduplicator;
+        _batchSubscribe = batchSubscribe;
+        _withDeduplication = withDeduplication;
 
-        public MyServiceBusSubscriber(
-            MyServiceBusTcpClient client, 
-            string topicName, string queueName, TopicQueueType queryType, bool batchSubscribe, 
-            bool withDeduplication)
+        if (!batchSubscribe)
         {
-            _batchSubscribe = batchSubscribe;
-            _withDeduplication = withDeduplication;
-            
-            if (!batchSubscribe)
+            client.Subscribe(topicName, queueName, queryType, HandlerBatchOneByOne);
+        }
+        else
+        {
+            client.Subscribe(topicName, queueName, queryType, HandlerBatch);
+        }
+
+        _chunkSize = 100;
+    }
+
+    public MyServiceBusSubscriber(MyServiceBusTcpClient client, string topicName, string queueName,
+        TopicQueueType queryType, bool batchSubscribe, int chunkSize)
+            : this(client, topicName, queueName, queryType, batchSubscribe, false)
+    {
+        _chunkSize = chunkSize;
+    }
+
+    public MyServiceBusSubscriber(MyServiceBusTcpClient client, string topicName, string queueName,
+        TopicQueueType queryType, IDeduplicator<T> deduplicator)
+        : this(client, topicName, queueName, queryType, false, true)
+    {
+        _withDeduplication = true;
+        _deduplicator = deduplicator;
+    }
+
+    public void SetDeserializeExceptionHandler(Action<Exception> deserializeExceptionHandler)
+    {
+        _deserializeExceptionHandler = deserializeExceptionHandler;
+    }
+
+    public void SetHeadersHandler(Action<Dictionary<string, string>> headersHandler)
+    {
+        _headersHandler = headersHandler;
+    }
+
+    private async ValueTask HandlerSingle(IMyServiceBusMessage data)
+    {
+        T item = default;
+        try
+        {
+            var message = data.Data.ByteArrayToServiceBusContract<T>();
+            item = message.Data;
+            _headersHandler?.Invoke(message.Headers);
+        }
+        catch (Exception ex)
+        {
+            if (_deserializeExceptionHandler != null)
             {
-                client.Subscribe(topicName, queueName, queryType, HandlerBatchOneByOne);
+                _deserializeExceptionHandler.Invoke(ex);
+                return;
             }
+            throw;
+        }
+
+        foreach (var subscribers in _list)
+            await subscribers(item);
+    }
+
+    private async ValueTask HandlerSingleWithDeduplication(IMyServiceBusMessage data)
+    {
+        T item = default;
+        try
+        {
+            var message = data.Data.ByteArrayToServiceBusContract<T>();
+            item = message.Data;
+            _headersHandler?.Invoke(message.Headers);
+        }
+        catch (Exception ex)
+        {
+            if (_deserializeExceptionHandler != null)
+            {
+                _deserializeExceptionHandler?.Invoke(ex);
+                return;
+            }
+            throw;
+        }
+
+        if (await _deduplicator.IsDuplicate(item))
+            return;
+
+        foreach (var subscribers in _list)
+            await subscribers(item);
+
+        await _deduplicator.AddToRegistry(item);
+    }
+
+    private async ValueTask HandlerBatchOneByOne(IConfirmationContext ctx, IReadOnlyList<IMyServiceBusMessage> data)
+    {
+        if (!data.Any())
+            return;
+
+        await Task.Yield();
+
+        foreach (var message in data.OrderBy(e => e.Id))
+        {
+            if (_withDeduplication)
+                await HandlerSingleWithDeduplication(message);
             else
+                await HandlerSingle(message);
+
+            ctx.ConfirmMessages([message.Id]);
+        }
+    }
+
+    private async ValueTask HandlerBatch(IConfirmationContext ctx, IReadOnlyList<IMyServiceBusMessage> data)
+    {
+        if (!data.Any())
+            return;
+
+        await Task.Yield();
+
+        if (data.Count <= _chunkSize)
+        {
+            await HandleBatchMessages(data);
+        }
+        else
+        {
+            var index = 0;
+            var chunk = data.OrderBy(e => e.Id).Skip(index).Take(_chunkSize).ToList();
+            while (chunk.Any())
             {
-                client.Subscribe(topicName, queueName, queryType, HandlerBatch);
+                await HandleBatchMessages(chunk);
+
+                ctx.ConfirmMessages(chunk.Select(e => e.Id));
+
+                index += _chunkSize;
+                chunk = data.OrderBy(e => e.Id).Skip(index).Take(_chunkSize).ToList();
             }
-
-            _chunkSize = 100;
         }
+    }
 
-        public MyServiceBusSubscriber(MyServiceBusTcpClient client, string topicName, string queueName,
-            TopicQueueType queryType, bool batchSubscribe, int chunkSize) 
-                : this(client,topicName, queueName, queryType, batchSubscribe, false)
-        {
-            _chunkSize = chunkSize;
-        }
-        
-        public MyServiceBusSubscriber(MyServiceBusTcpClient client, string topicName, string queueName,
-            TopicQueueType queryType, IDeduplicator<T> deduplicator) 
-            : this(client,topicName, queueName, queryType, false, true)
-        {
-            _withDeduplication = true;
-            _deduplicator = deduplicator;
-        }
+    private async Task HandleBatchMessages(IReadOnlyList<IMyServiceBusMessage> data)
+    {
+        if (!data.Any())
+            return;
 
-        public void SetDeserializeExceptionHandler(Action<Exception> deserializeExceptionHandler)
-        {
-            _deserializeExceptionHandler = deserializeExceptionHandler;
-        }
+        var items = new List<T>(data.Count);
 
-        private async ValueTask HandlerSingle(IMyServiceBusMessage data)
+        foreach (var mes in data)
         {
-            T item = default(T);
             try
             {
-                item = data.Data.ByteArrayToServiceBusContract<T>();
+                var message = mes.Data.ByteArrayToServiceBusContract<T>();
+                var item = message.Data;
+                _headersHandler?.Invoke(message.Headers);
+                items.Add(item);
             }
             catch (Exception ex)
             {
-                if (_deserializeExceptionHandler != null)
-                {
-                    _deserializeExceptionHandler.Invoke(ex);
-                    return;
-                }
-                throw;
-            }
-            
-            foreach (var subscribers in _list)
-                await subscribers(item);
-        }
-        
-        private async ValueTask HandlerSingleWithDeduplication(IMyServiceBusMessage data)
-        {
-            T item = default(T);
-            try
-            {
-                item = data.Data.ByteArrayToServiceBusContract<T>();
-            }
-            catch (Exception ex)
-            {
-                if (_deserializeExceptionHandler != null)
-                {
-                    _deserializeExceptionHandler?.Invoke(ex);
-                    return;
-                }
-                throw;
-            }
-            
-            if(await _deduplicator.IsDuplicate(item))
-                return;
-            
-            foreach (var subscribers in _list)
-                await subscribers(item);
-
-            await _deduplicator.AddToRegistry(item);
-        }
-        
-        private async ValueTask HandlerBatchOneByOne(IConfirmationContext ctx, IReadOnlyList<IMyServiceBusMessage> data)
-        {
-            if (!data.Any())
-                return;
-            
-            await Task.Yield();
-
-            foreach (var message in data.OrderBy(e => e.Id))
-            {
-                if (_withDeduplication)
-                    await HandlerSingleWithDeduplication(message);
-                else
-                    await HandlerSingle(message);
-                
-                ctx.ConfirmMessages(new []{message.Id});
+                _deserializeExceptionHandler?.Invoke(ex);
             }
         }
 
-        private async ValueTask HandlerBatch(IConfirmationContext ctx, IReadOnlyList<IMyServiceBusMessage> data)
-        {
-            if (!data.Any())
-                return;
-            
-            await Task.Yield();
-            
-            if (data.Count <= _chunkSize)
-            {
-                await HandleBatchMessages(data);
-            }
-            else
-            {
-                var index = 0;
-                var chunk = data.OrderBy(e => e.Id).Skip(index).Take(_chunkSize).ToList();
-                while (chunk.Any())
-                {
-                    await HandleBatchMessages(chunk);
-                    
-                    ctx.ConfirmMessages(chunk.Select(e => e.Id));
+        if (items.Count == 0)
+            return;
 
-                    index += _chunkSize;
-                    chunk = data.OrderBy(e => e.Id).Skip(index).Take(_chunkSize).ToList();
-                }
-            }
+        foreach (var callback in _listBatch)
+        {
+            await callback(items);
         }
+    }
 
-        private async Task HandleBatchMessages(IReadOnlyList<IMyServiceBusMessage> data)
-        {
-            if (!data.Any())
-                return;
-            
-            var items = new List<T>(data.Count);
-
-            if (_deserializeExceptionHandler == null)
-            {
-                items = data.Select(e => e.Data.ByteArrayToServiceBusContract<T>()).ToList();
-            }
-            else
-            {
-                foreach (var message in data)
-                {
-                    try
-                    {
-                        var item = message.Data.ByteArrayToServiceBusContract<T>();
-                        items.Add(item);
-                    }
-                    catch (Exception ex)
-                    {
-                        _deserializeExceptionHandler?.Invoke(ex);
-                    }
-                }
-            }
-            
-            if (!items.Any())
-                return;
-
-            foreach (var callback in _listBatch)
-            {
-                await callback(items);
-            }
-        }
-
-        public void Subscribe(Func<T, ValueTask> callback)
-        {
-            if (_batchSubscribe)
+    public void Subscribe(Func<T, ValueTask> callback)
+    {
+        if (_batchSubscribe)
                 throw new Exception("Cannot subscribe to single message, please use batch subscriber");
 
-            _list.Add(callback);
-        }
+        _list.Add(callback);
+    }
 
-        public void Subscribe(Func<IReadOnlyList<T>, ValueTask> callback)
-        {
-            if (!_batchSubscribe)
+    public void Subscribe(Func<IReadOnlyList<T>, ValueTask> callback)
+    {
+        if (!_batchSubscribe)
                 throw new Exception("Cannot subscribe to batch of message, please use single message subscriber");
 
-            _listBatch.Add(callback);
-        }
+        _listBatch.Add(callback);
     }
 }

--- a/src/MyJetWallet.Sdk.ServiceBus/MyServiceBusTcpClientFactory.cs
+++ b/src/MyJetWallet.Sdk.ServiceBus/MyServiceBusTcpClientFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Autofac;
 using DotNetCoreDecorators;
 using Microsoft.Extensions.Logging;
@@ -9,200 +8,266 @@ using MyJetWallet.Sdk.Service.LivnesProbs;
 using MyServiceBus.Abstractions;
 using MyServiceBus.TcpClient;
 
-namespace MyJetWallet.Sdk.ServiceBus
+namespace MyJetWallet.Sdk.ServiceBus;
+
+public static class MyServiceBusTcpClientFactory
 {
-    public static class MyServiceBusTcpClientFactory
+    public static MyServiceBusTcpClient Create(Func<string> getHostPort, ILogger logger)
     {
-        public static MyServiceBusTcpClient Create(Func<string> getHostPort, ILogger logger)
-        {
-            var name = ApplicationEnvironment.HostName ??
-                       $"{ApplicationEnvironment.AppName}:{ApplicationEnvironment.AppVersion}";
-            
-            var serviceBusClient = new MyServiceBusTcpClient(getHostPort, name);
-            serviceBusClient.Log.AddLogException(ex => logger.LogInformation(ex, "Exception in MyServiceBusTcpClient"));
-            serviceBusClient.Log.AddLogInfo(info => logger.LogDebug($"MyServiceBusTcpClient[info]: {info}"));
-            serviceBusClient.SocketLogs.AddLogInfo((context, msg) => logger.LogInformation($"MyServiceBusTcpClient[Socket {context?.Id}|{context?.ContextName}|{context?.Inited}][Info] {msg}"));
-            serviceBusClient.SocketLogs.AddLogException((context, exception) => logger.LogInformation(exception, $"MyServiceBusTcpClient[Socket {context?.Id}|{context?.ContextName}|{context?.Inited}][Exception] {exception.Message}"));
+        var name = ApplicationEnvironment.HostName ??
+                   $"{ApplicationEnvironment.AppName}:{ApplicationEnvironment.AppVersion}";
 
-            return serviceBusClient;
-        }
+        var serviceBusClient = new MyServiceBusTcpClient(getHostPort, name);
+        serviceBusClient.Log.AddLogException(ex => logger.LogInformation(ex, "Exception in MyServiceBusTcpClient"));
+        serviceBusClient.Log.AddLogInfo(info => logger.LogDebug($"MyServiceBusTcpClient[info]: {info}"));
+        serviceBusClient.SocketLogs.AddLogInfo((context, msg) => logger.LogInformation($"MyServiceBusTcpClient[Socket {context?.Id}|{context?.ContextName}|{context?.Inited}][Info] {msg}"));
+        serviceBusClient.SocketLogs.AddLogException((context, exception) => logger.LogInformation(exception, $"MyServiceBusTcpClient[Socket {context?.Id}|{context?.ContextName}|{context?.Inited}][Exception] {exception.Message}"));
 
-        public static MyServiceBusTcpClient RegisterMyServiceBusTcpClient(this ContainerBuilder builder, Func<string> getHostPort, ILoggerFactory loggerFactory)
-        {
-            var logger = loggerFactory.CreateLogger<MyServiceBusTcpClient>();
-            var client = Create(getHostPort, logger);
+        return serviceBusClient;
+    }
 
-            var manager = new ServiceBusManager(client, getHostPort?.Invoke());
-            builder.RegisterInstance(manager).As<IServiceBusManager>().SingleInstance();
+    public static MyServiceBusTcpClient RegisterMyServiceBusTcpClient(
+        this ContainerBuilder builder,
+        Func<string> getHostPort,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger<MyServiceBusTcpClient>();
+        var client = Create(getHostPort, logger);
 
-            builder.RegisterType<ServiceBusLifeTime>().AsSelf().As<ILivenessReporter>().SingleInstance().AutoActivate();
+        var manager = new ServiceBusManager(client, getHostPort?.Invoke());
+        builder.RegisterInstance(manager).As<IServiceBusManager>().SingleInstance();
 
-            return client;
-        }
+        builder.RegisterType<ServiceBusLifeTime>().AsSelf().As<ILivenessReporter>().SingleInstance().AutoActivate();
 
-        public static ContainerBuilder RegisterMyServiceBusPublisher<T>(this ContainerBuilder builder, MyServiceBusTcpClient client, string topicName, bool immediatelyPersist)
-        {
-            client.CreateTopicIfNotExists(topicName);
-            
-            // publisher
-            builder
-                .RegisterInstance(new MyServiceBusPublisher<T>(client, topicName, immediatelyPersist))
-                .As<IServiceBusPublisher<T>>()
-                .SingleInstance();
+        return client;
+    }
 
-            return builder;
-        }
+    public static ContainerBuilder RegisterMyServiceBusPublisher<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client,
+        string topicName, 
+        bool immediatelyPersist,
+        Action<Dictionary<string,string>> headersHandler = null)
+    {
+        client.CreateTopicIfNotExists(topicName);
 
-        public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
-            this ContainerBuilder builder, 
-            MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType)
-        {
-            var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, false, 100);
+        var pub = new MyServiceBusPublisher<T>(client, topicName, immediatelyPersist);
+        if (headersHandler is not null)
+            pub.SetHeadersHandler(headersHandler);
 
-            // single subscriber
-            builder
-                .RegisterInstance(subscriber)
-                .As<ISubscriber<T>>()
-                .SingleInstance();
+        // publisher
+        builder
+            .RegisterInstance(pub)
+            .As<IServiceBusPublisher<T>>()
+            .SingleInstance();
 
-            return builder;
-        }
-        
-        public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
-            this ContainerBuilder builder, 
-            MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType,
-            Action<Exception> deserializeExceptionHandler)
-        {
-            var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, false, 100);
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType)
+    {
+        var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, false, 100);
+
+        // single subscriber
+        builder
+            .RegisterInstance(subscriber)
+            .As<ISubscriber<T>>()
+            .SingleInstance();
+
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType,
+        Action<Exception> deserializeExceptionHandler)
+    {
+        var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, false, 100);
+        subscriber.SetDeserializeExceptionHandler(deserializeExceptionHandler);
+
+        // single subscriber
+        builder
+            .RegisterInstance(subscriber)
+            .As<ISubscriber<T>>()
+            .SingleInstance();
+
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType,
+        IDeduplicator<T> _deduplicator)
+    {
+        // single subscriber
+        builder
+            .RegisterInstance(new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, _deduplicator))
+            .As<ISubscriber<T>>()
+            .SingleInstance();
+
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType,
+        IDeduplicator<T> _deduplicator,
+        Action<Exception> deserializeExceptionHandler)
+    {
+        var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, _deduplicator);
+        subscriber.SetDeserializeExceptionHandler(deserializeExceptionHandler);
+
+        // single subscriber
+        builder
+            .RegisterInstance(subscriber)
+            .As<ISubscriber<T>>()
+            .SingleInstance();
+
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType,
+        IDeduplicator<T> _deduplicator = null,
+        Action<Exception> deserializeExceptionHandler = null,
+        Action<Dictionary<string, string>> headersHandler = null)
+    {
+        MyServiceBusSubscriber<T> subscriber;
+        if (_deduplicator is not null)
+            subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, _deduplicator);
+        else
+            subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, false, 100);
+        if (deserializeExceptionHandler is not null)
             subscriber.SetDeserializeExceptionHandler(deserializeExceptionHandler);
-            
-            // single subscriber
-            builder
-                .RegisterInstance(subscriber)
-                .As<ISubscriber<T>>()
-                .SingleInstance();
+        if (headersHandler is not null)
+            subscriber.SetHeadersHandler(headersHandler);
 
-            return builder;
-        }
-        
-        public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
-            this ContainerBuilder builder, 
-            MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType, 
-            IDeduplicator<T> _deduplicator)
-        {
-            // single subscriber
-            builder
-                .RegisterInstance(new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, _deduplicator))
-                .As<ISubscriber<T>>()
-                .SingleInstance();
+        // single subscriber
+        builder
+            .RegisterInstance(subscriber)
+            .As<ISubscriber<T>>()
+            .SingleInstance();
 
-            return builder;
-        }
-        
-        public static ContainerBuilder RegisterMyServiceBusSubscriberSingle<T>(
-            this ContainerBuilder builder, 
-            MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType, 
-            IDeduplicator<T> _deduplicator,
-            Action<Exception> deserializeExceptionHandler)
-        {
-            var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, _deduplicator);
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType,
+        Action<Exception> deserializeExceptionHandler)
+    {
+        var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, false);
+        subscriber.SetDeserializeExceptionHandler(deserializeExceptionHandler);
+
+        // batch subscriber
+        builder
+            .RegisterInstance(subscriber)
+            .As<ISubscriber<IReadOnlyList<T>>>()
+            .SingleInstance();
+
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType)
+    {
+        // batch subscriber
+        builder
+            .RegisterInstance(new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, false))
+            .As<ISubscriber<IReadOnlyList<T>>>()
+            .SingleInstance();
+
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType, int chunkSize)
+    {
+        // batch subscriber
+        builder
+            .RegisterInstance(new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, chunkSize))
+            .As<ISubscriber<IReadOnlyList<T>>>()
+            .SingleInstance();
+
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType, int chunkSize,
+        Action<Exception> deserializeExceptionHandler)
+    {
+        var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, chunkSize);
+        subscriber.SetDeserializeExceptionHandler(deserializeExceptionHandler);
+
+        // batch subscriber
+        builder
+            .RegisterInstance(subscriber)
+            .As<ISubscriber<IReadOnlyList<T>>>()
+            .SingleInstance();
+
+        return builder;
+    }
+
+    public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
+        this ContainerBuilder builder,
+        MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType, 
+        int chunkSize = 100,
+        Action<Exception> deserializeExceptionHandler = null,
+        Action<Dictionary<string, string>> headersHandler = null)
+    {
+        var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, chunkSize);
+        if (deserializeExceptionHandler is not null)
             subscriber.SetDeserializeExceptionHandler(deserializeExceptionHandler);
-            
-            // single subscriber
-            builder
-                .RegisterInstance(subscriber)
-                .As<ISubscriber<T>>()
-                .SingleInstance();
+        if (headersHandler is not null)
+            subscriber.SetHeadersHandler(headersHandler);
 
-            return builder;
-        }
+        // batch subscriber
+        builder
+            .RegisterInstance(subscriber)
+            .As<ISubscriber<IReadOnlyList<T>>>()
+            .SingleInstance();
 
-        public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
-            this ContainerBuilder builder, 
-            MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType,
-            Action<Exception> deserializeExceptionHandler)
+        return builder;
+    }
+
+    public static MyServiceBusDeduplicator<T> RegisterMyServiceBusDeduplicator<T>(
+        this ContainerBuilder builder,
+        Func<T, string> tToStrFunc,
+        Func<string> noSqlWriterUrl,
+        string tableName,             
+        string topicName,
+        TimeSpan expirationTime,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger<MyServiceBusDeduplicator<T>>();
+
+        var deduplicator = new MyServiceBusDeduplicator<T>(tToStrFunc, noSqlWriterUrl, tableName, topicName,
+            expirationTime, logger);
+
+        builder
+            .RegisterInstance(deduplicator)
+            .As<IDeduplicator<T>>()
+            .SingleInstance();
+
+        return deduplicator;
+    }
+
+
+    private static ILogger _deserializeExceptionHandlerLogger = null;
+    public static Action<Exception> GetDeserializeExceptionHandlerLogger(ILoggerFactory loggerFactory, string topicName)
+    {
+        if (_deserializeExceptionHandlerLogger == null)
+            _deserializeExceptionHandlerLogger = loggerFactory.CreateLogger("ServiceBusDeserializeLogger");
+
+        return ex =>
         {
-            var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, false);
-            subscriber.SetDeserializeExceptionHandler(deserializeExceptionHandler);
-            
-            // batch subscriber
-            builder
-                .RegisterInstance(subscriber)
-                .As<ISubscriber<IReadOnlyList<T>>>()
-                .SingleInstance();
-
-            return builder;
-        }
-        
-        public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
-            this ContainerBuilder builder, 
-            MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType)
-        {
-            // batch subscriber
-            builder
-                .RegisterInstance(new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, false))
-                .As<ISubscriber<IReadOnlyList<T>>>()
-                .SingleInstance();
-
-            return builder;
-        }
-        
-        public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
-            this ContainerBuilder builder, 
-            MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType, int chunkSize)
-        {
-            // batch subscriber
-            builder
-                .RegisterInstance(new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, chunkSize))
-                .As<ISubscriber<IReadOnlyList<T>>>()
-                .SingleInstance();
-
-            return builder;
-        }
-        
-        public static ContainerBuilder RegisterMyServiceBusSubscriberBatch<T>(
-            this ContainerBuilder builder, 
-            MyServiceBusTcpClient client, string topicName, string queueName, TopicQueueType queryType, int chunkSize,
-            Action<Exception> deserializeExceptionHandler)
-        {
-            var subscriber = new MyServiceBusSubscriber<T>(client, topicName, queueName, queryType, true, chunkSize);
-            subscriber.SetDeserializeExceptionHandler(deserializeExceptionHandler);
-            
-            // batch subscriber
-            builder
-                .RegisterInstance(subscriber)
-                .As<ISubscriber<IReadOnlyList<T>>>()
-                .SingleInstance();
-
-            return builder;
-        }
-
-        public static MyServiceBusDeduplicator<T> RegisterMyServiceBusDeduplicator<T>(this ContainerBuilder builder, Func<T, string> tToStrFunc, Func<string> noSqlWriterUrl, string tableName, string topicName, TimeSpan expirationTime, ILoggerFactory loggerFactory)
-        {
-            var logger = loggerFactory.CreateLogger<MyServiceBusDeduplicator<T>>();
-
-            var deduplicator = new MyServiceBusDeduplicator<T>(tToStrFunc, noSqlWriterUrl, tableName, topicName,
-                expirationTime, logger);
-            
-            builder
-                .RegisterInstance(deduplicator)
-                .As<IDeduplicator<T>>()
-                .SingleInstance();
-
-            return deduplicator;
-        }
-
-
-        private static ILogger _deserializeExceptionHandlerLogger = null;
-        public static Action<Exception> GetDeserializeExceptionHandlerLogger(ILoggerFactory loggerFactory, string topicName)
-        {
-            if (_deserializeExceptionHandlerLogger == null)
-                _deserializeExceptionHandlerLogger = loggerFactory.CreateLogger("ServiceBusDeserializeLogger");
-
-            return ex =>
-            {
-                _deserializeExceptionHandlerLogger.LogError(ex, "Cannot Deserialize message from TOPIC {topicName}. Message was SKIPPED", topicName);
-            };
-        }
+            _deserializeExceptionHandlerLogger.LogError(ex, "Cannot Deserialize message from TOPIC {topicName}. Message was SKIPPED", topicName);
+        };
     }
 }

--- a/test/MyJetWallet.Sdk.ServiceBus.Tests/HeadersTests.cs
+++ b/test/MyJetWallet.Sdk.ServiceBus.Tests/HeadersTests.cs
@@ -1,0 +1,42 @@
+using System.Runtime.Serialization;
+
+namespace MyJetWallet.Sdk.ServiceBus.Tests;
+
+public class HeadersTests
+{
+    [DataContract]
+    private class TestObj
+    {
+        [DataMember(Order = 1)]
+        public required string Prop1 { get; init; }
+    }
+    private readonly Dictionary<string, string> headers = new()
+    {
+        {"key1", "value1"},
+        {"key2", "value2"}
+    };
+    private readonly TestObj obj = new() { Prop1 = "test" };
+
+
+    [Test]
+    public void SerializeDeserializeWithHeadersTest()
+    {
+        ReadOnlyMemory<byte> bytes = DomainToContractMapper.ServiceBusContractToByteArray(obj, headers);
+
+        var res = bytes.ByteArrayToServiceBusContract<TestObj>();
+
+        Assert.That(res.Data.Prop1, Is.EqualTo(obj.Prop1));
+        CollectionAssert.AreEqual(headers, res.Headers);
+    }
+
+    [Test]
+    public void SerializeDeserializeWithoutHeadersTest()
+    {
+        ReadOnlyMemory<byte> bytes = DomainToContractMapper.ServiceBusContractToByteArray(obj);
+
+        var res = bytes.ByteArrayToServiceBusContract<TestObj>();
+
+        Assert.That(res.Data.Prop1, Is.EqualTo(obj.Prop1));
+        CollectionAssert.IsEmpty(res.Headers);
+    }
+}

--- a/test/MyJetWallet.Sdk.ServiceBus.Tests/MyJetWallet.Sdk.ServiceBus.Tests.csproj
+++ b/test/MyJetWallet.Sdk.ServiceBus.Tests/MyJetWallet.Sdk.ServiceBus.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MyJetWallet.Sdk.ServiceBus\MyJetWallet.Sdk.ServiceBus.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Updated ContractToDomainMapper and DomainToContractMapper to be able pass headers with messages
- Added MessageWithHeaders<T> for deserealizing message
- Added header handler for publisher with ability to set up headers for all messages as well as for specific messages
- Added header handler for subscriber to process all inbound message's headers
- Updated MyServiceBusTcpClientFactory to pass header handlers when register publisher/subscriber
- Added UnitTest project to test new version of protocol